### PR TITLE
Lint auto fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## npm install
 ## npm run lint
+If it fails run: ./node_modules/.bin/eslint app/*.js test/*.js --fix
+
+To autofix any errors that can be --fix ed
 ## npm test
 ## npm start
 

--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,6 @@
-const express = require('express')
-const app = express()
-const nunjucks = require('nunjucks')
+const express = require('express');
+const app = express();
+const nunjucks = require('nunjucks');
 const bodyParser = require('body-parser');
 const JobRoles = require('./JobRoles');
 
@@ -11,10 +11,13 @@ nunjucks.configure('views', {
 	autoescape: true,
 	express: app 
 }); 
+
 /* Provide Public files such as Images & Styling */
 app.use(express.static('public'));
+
 /* Nunjucks view engine */
 app.set('view engine', 'html');
+
 /* Index (Home Page) Route */
 app.get('/', function (req, res) { 
 	res.render('index');

--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const app = express();
-const nunjucks = require('nunjucks');
+const express = require('express')
+const app = express()
+const nunjucks = require('nunjucks')
 const bodyParser = require('body-parser');
 const JobRoles = require('./JobRoles');
 
@@ -11,13 +11,10 @@ nunjucks.configure('views', {
 	autoescape: true,
 	express: app 
 }); 
-
 /* Provide Public files such as Images & Styling */
 app.use(express.static('public'));
-
 /* Nunjucks view engine */
 app.set('view engine', 'html');
-
 /* Index (Home Page) Route */
 app.get('/', function (req, res) { 
 	res.render('index');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "nodemon app/server.js",
     "test": "jest --passWithNoTests --detectOpenHandles",
-    "lint": "./node_modules/.bin/eslint app/*.js test/*.js --fix"
+    "lint": "./node_modules/.bin/eslint app/*.js test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
ESLint --fix command removed.

nom run lint will now show any errors and the developer must then run the local command with the --fix option to clean any errors that can be auto fixed.

This now ensures that a build that would fail the lint check does not get accidentally approved because the --fix fixes it, although it does not push the fixed version.